### PR TITLE
Add in support for obj groups

### DIFF
--- a/obj2ms3dascii.mjs
+++ b/obj2ms3dascii.mjs
@@ -13,7 +13,7 @@ export function obj2ms3dascii( obj, mtl ) {
   };
 
   let currentObject = null;
-  const unfiltered_objects = [];
+  const unfilteredObjects = [];
 
   // let mtlPath = null;
 
@@ -54,7 +54,7 @@ export function obj2ms3dascii( obj, mtl ) {
     }
   } );
   
-  const objects = unfiltered_objects.filter((x) => x.f.length > 0);
+  const objects = unfiltered_objects.filter( ( x ) => x.f.length > 0 );
 
   // -- read .mtl ----------------------------------------------------------------------------------
   // if ( mtlPath == null ) {

--- a/obj2ms3dascii.mjs
+++ b/obj2ms3dascii.mjs
@@ -13,7 +13,7 @@ export function obj2ms3dascii( obj, mtl ) {
   };
 
   let currentObject = null;
-  const unfilteredObjects = [];
+  const unfilteredObjects = []; // all found objects before being filtered to remove "invalid" objects
 
   // let mtlPath = null;
 
@@ -31,7 +31,7 @@ export function obj2ms3dascii( obj, mtl ) {
         name: li[ 1 ],
         f: [],
       };
-      unfiltered_objects.push( currentObject );
+      unfilteredObjects.push( currentObject );
     } else if ( li[ 0 ] === 'v' ) {
       const vertex = [ li[ 1 ], li[ 2 ], li[ 3 ] ].map( ( v ) => parseFloat( v ) );
       vertices.v.push( vertex );
@@ -54,7 +54,8 @@ export function obj2ms3dascii( obj, mtl ) {
     }
   } );
   
-  const objects = unfiltered_objects.filter( ( x ) => x.f.length > 0 );
+  // Filter out "invalid" objects
+  const objects = unfilteredObjects.filter( ( x ) => x.f.length > 0 );
 
   // -- read .mtl ----------------------------------------------------------------------------------
   // if ( mtlPath == null ) {

--- a/obj2ms3dascii.mjs
+++ b/obj2ms3dascii.mjs
@@ -13,7 +13,7 @@ export function obj2ms3dascii( obj, mtl ) {
   };
 
   let currentObject = null;
-  const objects = [];
+  const unfiltered_objects = [];
 
   // let mtlPath = null;
 
@@ -26,12 +26,12 @@ export function obj2ms3dascii( obj, mtl ) {
 
     if ( li[ 0 ] === 'mtllib' ) {
       // mtlPath = li[ 1 ];
-    } else if ( li[ 0 ] === 'o' ) {
+    } else if ( li[ 0 ] === 'o' || li[ 0 ] === 'g' ) {
       currentObject = {
         name: li[ 1 ],
         f: [],
       };
-      objects.push( currentObject );
+      unfiltered_objects.push( currentObject );
     } else if ( li[ 0 ] === 'v' ) {
       const vertex = [ li[ 1 ], li[ 2 ], li[ 3 ] ].map( ( v ) => parseFloat( v ) );
       vertices.v.push( vertex );
@@ -53,6 +53,8 @@ export function obj2ms3dascii( obj, mtl ) {
       currentObject.usemtl = li[ 1 ];
     }
   } );
+  
+  const objects = unfiltered_objects.filter((x) => x.f.length > 0);
 
   // -- read .mtl ----------------------------------------------------------------------------------
   // if ( mtlPath == null ) {


### PR DESCRIPTION
Blender seems to export multi-material objects as object groups with no way to disable it (perhaps new to blender 3? I assume people have been able to export multi-material objects through blender in the past). This adds support for the 'g' tag in obj files.

Tested locally and seems to work in all situations I've tried it with! Results import into notitg fine.